### PR TITLE
Support explicit infinity parsing from strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,12 @@ the `bound` parameter can be used to specify the regular expression that should 
 
 ```
 
+Infinity can be expressed as `inf`, `-inf`, or `+inf`, and will be mapped accordingly.
 
+```python
+>>> I.from_string('(10,inf)', conv=int) == I.open(10, I.inf)
+True
+```
 
 ## Contributions
 
@@ -390,7 +395,7 @@ This library adheres to a [semantic versioning](https://semver.org) scheme.
 **1.5.3** (2018-06-21)
 
  - Fix invalid `repr` for atomic singleton intervals.
- 
+
 
 **1.5.2** (2018-06-15)
 

--- a/intervals.py
+++ b/intervals.py
@@ -1,7 +1,7 @@
 import re
 
 __package__ = 'python-intervals'
-__version__ = '1.5.4'
+__version__ = '1.5.5'
 __licence__ = 'LGPL3'
 __author__ = 'Alexandre Decan'
 __url__ = 'https://github.com/AlexandreDecan/python-intervals'
@@ -148,8 +148,9 @@ def from_string(string, conv, bound=r'.+?', disj=r' ?\| ?', sep=r', ?', left_ope
 
             lower = group.get('lower', None)
             upper = group.get('upper', None)
-            lower = conv(lower) if lower is not None else inf
-            upper = conv(upper) if upper is not None else lower
+
+            lower = __conv_with_infinity(lower, conv) if lower is not None else inf
+            upper = __conv_with_infinity(upper, conv) if upper is not None else lower
 
             intervals.append(AtomicInterval(left, lower, upper, right))
             string = string[match.end():]
@@ -190,6 +191,15 @@ def to_string(interval, conv=repr, disj=' | ', sep=',', left_open='(', left_clos
             exported_intervals.append('{}{}{}{}{}'.format(left, lower, sep, upper, right))
 
     return disj.join(exported_intervals)
+
+
+def __conv_with_infinity(value, conv):
+    if value == 'inf' or value == '+inf':
+        return inf
+    elif value == '-inf':
+        return -inf
+    else:
+        return conv(value)
 
 
 class AtomicInterval:

--- a/test_intervals.py
+++ b/test_intervals.py
@@ -117,6 +117,10 @@ def test_from_string():
     assert I.from_string('()', int) == I.empty()
     assert I.from_string('[1]', int) == I.singleton(1)
 
+    assert I.from_string('[1,inf)', int) == I.closed(1, I.inf)
+    assert I.from_string('(1,+inf)', int) == I.open(1, I.inf)
+    assert I.from_string('(-inf,1)', int) == I.open(-I.inf, 1)
+
     assert I.from_string('[0,1] | [2,3]', int) == I.closed(0, 1) | I.closed(2, 3)
 
     with pytest.raises(Exception):
@@ -167,16 +171,16 @@ def test_overlaps():
         I.closed(0, 1).to_atomic().overlaps(1)
     with pytest.raises(TypeError):
         I.closed(0, 1).overlaps(1)
-        
+
     assert I.closed(0, 1).overlaps(I.closed(0, 1))
     assert I.closed(0, 1).overlaps(I.open(0, 1))
     assert I.open(0, 1).overlaps(I.closed(0, 1))
     assert I.closed(0, 1).overlaps(I.openclosed(0, 1))
     assert I.closed(0, 1).overlaps(I.closedopen(0, 1))
 
-    assert I.closed(1, 2).overlaps(I.closed(2, 3)) 
+    assert I.closed(1, 2).overlaps(I.closed(2, 3))
     assert I.closed(1, 2).overlaps(I.closedopen(2, 3))
-    assert I.openclosed(1, 2).overlaps(I.closed(2, 3)) 
+    assert I.openclosed(1, 2).overlaps(I.closed(2, 3))
     assert I.openclosed(1, 2).overlaps(I.closedopen(2, 3))
 
     assert not I.closed(0, 1).overlaps(I.closed(3, 4))
@@ -201,9 +205,9 @@ def test_overlaps_permissive():
     assert I.closed(0, 1).overlaps(I.openclosed(0, 1), permissive=True)
     assert I.closed(0, 1).overlaps(I.closedopen(0, 1), permissive=True)
 
-    assert I.closed(1, 2).overlaps(I.closed(2, 3), permissive=True) 
+    assert I.closed(1, 2).overlaps(I.closed(2, 3), permissive=True)
     assert I.closed(1, 2).overlaps(I.closedopen(2, 3), permissive=True)
-    assert I.openclosed(1, 2).overlaps(I.closed(2, 3), permissive=True) 
+    assert I.openclosed(1, 2).overlaps(I.closed(2, 3), permissive=True)
     assert I.openclosed(1, 2).overlaps(I.closedopen(2, 3), permissive=True)
 
     assert not I.closed(0, 1).overlaps(I.closed(3, 4), permissive=True)
@@ -219,7 +223,7 @@ def test_overlaps_permissive():
 
     assert not I.empty().overlaps(I.open(-I.inf, I.inf), permissive=True)
     assert not I.open(-I.inf, I.inf).overlaps(I.empty(), permissive=True)
-    
+
 
 def test_emptiness():
     assert I.openclosed(1, 1).is_empty()


### PR DESCRIPTION
When we call `I.to_string` with an infinity we render `(123,inf)`, but we cannot parse that back in 😔. This change allows us to parse this back into an interval. 

For example:

```python
>>> import intervals as I
>>> I.__version__
'1.5.5'
>>> ival = I.open(50,I.inf)
>>> ival
(50,+inf)
>>> istr = I.to_string(ival)
>>> istr
'(50,+inf)'
>>> inew = I.from_string(istr, conv=int)
>>> inew
(50,+inf)
>>> inew == ival
True
```

Hope this looks okay? I'm not especially skilled-up on Python...