### PR TITLE
Support import/export to a list of 4-uples (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ The `AtomicInterval` objects of an `Interval` can also be accessed using their i
 
 ```
 
-### Import and export to string
+### Import and export intervals to strings
 
 Intervals can be exported to string, either using `repr` (as illustrated above) or with the `to_string` function.
 
@@ -348,8 +348,8 @@ A conversion function (`conv` parameter) has to be provided to convert a bound (
 True
 >>> I.from_string('[1.2]', conv=float) == I.singleton(1.2)
 True
->>> from datetime import datetime
->>> converter = lambda s: datetime.strptime(s, '%Y/%m/%d')
+>>> import datetime
+>>> converter = lambda s: datetime.datetime.strptime(s, '%Y/%m/%d')
 >>> I.from_string('[2011/03/15, 2013/10/10]', conv=converter)
 [datetime.datetime(2011, 3, 15, 0, 0),datetime.datetime(2013, 10, 10, 0, 0)]
 
@@ -387,6 +387,38 @@ the `bound` parameter can be used to specify the regular expression that should 
 ```
 
 
+### Import and export intervals to a list of 4-uples
+
+Intervals can also be exported to a list of 4-uples with `to_data`, e.g., to support JSON serialization.
+
+```python
+>>> x = I.openclosed(0, 1) | I.closedopen(2, I.inf)
+>>> I.to_data(x)
+[(False, 0, 1, True), (True, 2, inf, False)]
+
+```
+
+The function that is used to convert bounds can be specified with the `conv` parameter.
+The values that must be used to represent positive and negative infinities can be specified with
+`pinf` and `ninf`, respectively.
+
+```python
+>>> x = I.closedopen(datetime.datetime(2011, 1, 1), I.inf)
+>>> I.to_data(x, conv=lambda v: v.year, pinf=datetime.MAXYEAR)
+[(True, 2011, 9999, False)]
+
+```
+
+Intervals can be imported from such a list of 4-uples with `from_data`. 
+The same set of parameters can be used to specify how bounds and infinities are converted.
+
+```python
+>>> x = [(True, 2011, 9999, False), (False, 1998, 1999, True)]
+>>> I.from_data(x, conv=lambda v: datetime.datetime(v, 1, 1), pinf=datetime.MAXYEAR)
+(datetime.datetime(1998, 1, 1, 0, 0),datetime.datetime(1999, 1, 1, 0, 0)] | [datetime.datetime(2011, 1, 1, 0, 0),+inf)
+
+```
+
 
 ## Contributions
 
@@ -402,6 +434,11 @@ Distributed under [LGPLv3 - GNU Lesser General Public License, version 3](https:
 ## Changelog
 
 This library adheres to a [semantic versioning](https://semver.org) scheme.
+
+
+**1.7.0** (2018-12-06)
+
+ - Import from and export to list of 4-uples with `from_data` and `to_data` ([#6](https://github.com/AlexandreDecan/python-intervals/issues/6)).
 
 
 **1.6.0** (2018-08-29)

--- a/test_intervals.py
+++ b/test_intervals.py
@@ -162,6 +162,29 @@ def test_from_string_customized():
     assert I.from_string('<"0"-"1"> or <"2"-"3">', **params) == I.closed(0, 1) | I.closed(2, 3)
 
 
+def test_to_data():
+    assert I.to_data(I.closedopen(2, 3)) == [(I.CLOSED, 2, 3, I.OPEN)]
+    assert I.to_data(I.openclosed(2, I.inf)) == [(I.OPEN, 2, float('inf'), I.OPEN)]
+    assert I.to_data(I.closed(-I.inf, 2)) == [(I.OPEN, float('-inf'), 2, I.CLOSED)]
+
+    i = I.openclosed(-I.inf, 4) | I.closedopen(6, I.inf)
+    assert I.to_data(i) == [(I.OPEN, float('-inf'), 4, I.CLOSED), (I.CLOSED, 6, float('inf'), I.OPEN)]
+    assert I.to_data(i, conv=str, pinf='highest', ninf='lowest') == [(I.OPEN, 'lowest', '4', I.CLOSED), (I.CLOSED, '6', 'highest', I.OPEN)]
+
+
+def test_from_data():
+    assert I.from_data([(I.CLOSED, 2, 3, I.OPEN)]) == I.closedopen(2, 3)
+    assert I.from_data([(I.OPEN, 2, float('inf'), I.OPEN)]) == I.openclosed(2, I.inf)
+    assert I.from_data([(I.OPEN, float('-inf'), 2, I.CLOSED)]) == I.closed(-I.inf, 2)
+
+    d = [(I.OPEN, float('-inf'), 4, I.CLOSED), (I.CLOSED, 6, float('inf'), I.OPEN)]
+    assert I.from_data(d) == I.openclosed(-I.inf, 4) | I.closedopen(6, I.inf)
+
+    d = [(I.OPEN, 'lowest', '4', I.CLOSED), (I.CLOSED, '6', 'highest', I.OPEN)]
+    assert I.from_data(d, conv=int, pinf='highest', ninf='lowest') == I.openclosed(-I.inf, 4) | I.closedopen(6, I.inf)
+
+
+
 def test_interval_to_atomic():
     intervals = [I.closed(0, 1), I.open(0, 1), I.openclosed(0, 1), I.closedopen(0, 1)]
     for interval in intervals:


### PR DESCRIPTION
I still need to find why tests are failing in Python 2.7. 