### PR TITLE
Make left, right, lower and upper available on Interval instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,7 @@ This library adheres to a [semantic versioning](https://semver.org) scheme.
 **1.8.0** (2018-12-11)
 
  - `Interval` instances also have a `left`, `lower`, `upper`, and `right` attribute.
+ - Infinities are singleton objects (Python 3+ only).
  
 
 **1.7.0** (2018-12-06)

--- a/intervals.py
+++ b/intervals.py
@@ -1,7 +1,7 @@
 import re
 
 __package__ = 'python-intervals'
-__version__ = '1.7.0'
+__version__ = '1.8.0'
 __licence__ = 'LGPL3'
 __author__ = 'Alexandre Decan'
 __url__ = 'https://github.com/AlexandreDecan/python-intervals'
@@ -16,7 +16,15 @@ __all__ = [
 ]
 
 
-class _PInf:
+class _Singleton():
+    __instance = None
+    def __new__(cls, *args, **kwargs):
+        if not cls.__instance:
+            cls.__instance = super(_Singleton, cls).__new__(cls, *args, **kwargs)
+        return cls.__instance
+
+
+class _PInf(_Singleton):
     """
     Represent positive infinity.
     """
@@ -38,7 +46,7 @@ class _PInf:
     def __repr__(self): return '+inf'
 
 
-class _NInf:
+class _NInf(_Singleton):
     """
     Represent negative infinity.
     """
@@ -637,6 +645,33 @@ class Interval:
                     self._intervals.insert(i, interval)
                 else:
                     i = i + 1
+    @property
+    def left(self):
+        """
+        Boolean indicating whether the lowest left boundary is inclusive (True) or exclusive (False).
+        """
+        return self._intervals[0].left
+
+    @property
+    def lower(self):
+        """
+        Lowest lower bound value.
+        """
+        return self._intervals[0].lower
+
+    @property
+    def upper(self):
+        """
+        Highest upper bound value.
+        """
+        return self._intervals[-1].upper
+
+    @property
+    def right(self):
+        """
+        Boolean indicating whether the highest right boundary is inclusive (True) or exclusive (False).
+        """
+        return self._intervals[-1].right
 
     def is_empty(self):
         """

--- a/test_intervals.py
+++ b/test_intervals.py
@@ -21,6 +21,19 @@ def test_infinity_comparisons_with_self(inf):
     assert not (inf != inf)
 
 
+@pytest.mark.skipif(sys.version_info < (3,0), reason='Not supported in Python 2')
+def test_infinities_are_singletons():
+    assert I._PInf() == I._PInf()
+    assert I._PInf() is I._PInf()
+    assert I._PInf() is -I._NInf()
+
+    assert I._NInf() == I._NInf()
+    assert I._NInf() is I._NInf()
+
+    assert I._PInf() is not I._NInf()
+    assert I._PInf() is not -I._PInf()
+
+
 @pytest.mark.parametrize('o', [0, 1, 1.0, 'a', list(), tuple(), dict(), I.closed(0, 1)])
 def test_infinity_comparisons_with_objects(o):
     assert o != I.inf and not (o == I.inf)
@@ -52,6 +65,40 @@ def test_creation():
 
     with pytest.raises(TypeError):
         I.Interval(1)
+
+
+def test_atomic_bounds():
+    i = I.openclosed(1, 2).to_atomic()
+    assert i.left == I.OPEN
+    assert i.right == I.CLOSED
+    assert i.lower == 1
+    assert i.upper == 2
+
+    i = I.openclosed(10, -10).to_atomic()
+    assert i.left == I.OPEN
+    assert i.right == I.OPEN
+    assert i.lower == I.inf
+    assert i.upper == -I.inf
+    
+
+def test_bounds():
+    i = I.openclosed(1, 2)
+    assert i.left == I.OPEN
+    assert i.right == I.CLOSED
+    assert i.lower == 1
+    assert i.upper == 2
+
+    i = I.openclosed(10, -10)
+    assert i.left == I.OPEN
+    assert i.right == I.OPEN
+    assert i.lower == I.inf
+    assert i.upper == -I.inf
+
+    i = I.open(0, 1) | I.closed(3, 4)
+    assert i.left == I.OPEN
+    assert i.right == I.CLOSED
+    assert i.lower == 0
+    assert i.upper == 4
 
 
 def test_hash():


### PR DESCRIPTION
Indirectly addresses #8 